### PR TITLE
Fix bleep sound paths for GitHub Pages deployment

### DIFF
--- a/lib/utils/audioProcessor.ts
+++ b/lib/utils/audioProcessor.ts
@@ -2,6 +2,8 @@
  * Audio processing utilities for applying bleeps/censoring
  */
 
+import { getPublicPath } from './paths'
+
 export interface BleepSegment {
   word: string
   start: number
@@ -40,7 +42,7 @@ export async function applyBleeps(
   gainNode.connect(offlineContext.destination)
   
   // Load bleep sound
-  const bleepResponse = await fetch(`/bleeps/${bleepSound}.mp3`)
+  const bleepResponse = await fetch(getPublicPath(`/bleeps/${bleepSound}.mp3`))
   const bleepArrayBuffer = await bleepResponse.arrayBuffer()
   const bleepBuffer = await audioContext.decodeAudioData(bleepArrayBuffer)
   

--- a/lib/utils/paths.ts
+++ b/lib/utils/paths.ts
@@ -8,8 +8,9 @@
  * @returns The path with the correct base path prepended
  */
 export function getPublicPath(path: string): string {
-  const basePath = process.env.NODE_ENV === 'production' 
-    ? '/bleep-that-shit' 
+  // Check if we're on GitHub Pages by looking at the pathname
+  const basePath = typeof window !== 'undefined' && window.location.pathname.startsWith('/bleep-that-shit')
+    ? '/bleep-that-shit'
     : '';
   return `${basePath}${path}`;
 }


### PR DESCRIPTION
- Update getPublicPath to detect GitHub Pages at runtime using window.location
- Use getPublicPath for loading bleep sounds in audioProcessor
- This ensures bleeps load from /bleep-that-shit/bleeps/ on GitHub Pages