### PR TITLE
Fix GitHub repository links across the codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ https://github.com/user-attachments/assets/da50f8a9-27ba-4747-92e0-72a25e65175c
 
 Let's look more closely at the last example above - below is a short clip we'll bleep out some words from using the pipeline in this repo. (make sure to turn on audio - its off by default)
 
-https://github.com/neonwatty/bleep_that_sht/assets/16326421/fb8568fe-aba0-49e2-a563-642d658c0651
+https://github.com/neonwatty/bleep-that-shit/assets/16326421/fb8568fe-aba0-49e2-a563-642d658c0651
 
 Now the same clip with the words - "treetz", "ice", "cream", "chocolate", "syrup", and "cookie" - bleeped out
 
-https://github.com/neonwatty/bleep_that_sht/assets/16326421/63ebd7a0-46f6-4efd-80ea-20512ff427c0
+https://github.com/neonwatty/bleep-that-shit/assets/16326421/63ebd7a0-46f6-4efd-80ea-20512ff427c0
 
 ---
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -151,7 +151,7 @@ export default function Home() {
         </div>
         <div className="flex justify-center mb-4">
           <a 
-            href="https://github.com/neonwatty/bleep-that-sh*t" 
+            href="https://github.com/neonwatty/bleep-that-shit" 
             target="_blank" 
             rel="noopener" 
             className="btn btn-secondary btn-blue flex items-center gap-2" 

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -7,7 +7,7 @@ export function Footer() {
         </div>
         <div className="flex gap-6">
           <a 
-            href="https://github.com/neonwatty/bleep-that-sh*t" 
+            href="https://github.com/neonwatty/bleep-that-shit" 
             target="_blank" 
             rel="noopener noreferrer"
             className="text-gray-700 hover:text-black transition-colors"


### PR DESCRIPTION
- Updated incorrect repository URLs from variations like 'bleep-that-sh*t' and 'bleep_that_sht' to the correct 'bleep-that-shit'
- Fixed links in components/Footer.tsx, app/page.tsx, and README.md
- Ensures all GitHub links point to the correct repository URL

🤖 Generated with [Claude Code](https://claude.ai/code)