### PR TITLE
Re-add Polish, Dutch, and Korean language support

### DIFF
--- a/app/bleep/page.tsx
+++ b/app/bleep/page.tsx
@@ -496,8 +496,11 @@ export default function BleepPage() {
               <option value="de">German</option>
               <option value="it">Italian</option>
               <option value="pt">Portuguese</option>
+              <option value="nl">Dutch</option>
+              <option value="pl">Polish</option>
               <option value="ja">Japanese</option>
               <option value="zh">Chinese</option>
+              <option value="ko">Korean</option>
             </select>
           </div>
           

--- a/app/sampler/page.tsx
+++ b/app/sampler/page.tsx
@@ -295,8 +295,11 @@ export default function SamplerPage() {
                 <option value="de">German</option>
                 <option value="it">Italian</option>
                 <option value="pt">Portuguese</option>
+                <option value="nl">Dutch</option>
+                <option value="pl">Polish</option>
                 <option value="ja">Japanese</option>
                 <option value="zh">Chinese</option>
+                <option value="ko">Korean</option>
               </select>
             </div>
           </div>


### PR DESCRIPTION
These languages were accidentally omitted during the Rails-to-Next.js migration (commit 7cda522). All three are fully supported by OpenAI Whisper models.

- Added Polish (pl) to language selectors
- Added Dutch (nl) to language selectors
- Added Korean (ko) to language selectors
- Updated both /bleep and /sampler pages
